### PR TITLE
call addTopics to reconnect existing topics on session reconnect

### DIFF
--- a/.changeset/ninety-weeks-fail.md
+++ b/.changeset/ninety-weeks-fail.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': minor
+---
+
+Bug fix: Call addTopics in BaseNamespace.subscribe to resubscribe existing topics when the ws session reconnects.


### PR DESCRIPTION
# Description

When the session is disconnected and reconnected, existing topics need to be resubscribed. This fix for BaseNamespace class mimics how the issue is handled for channels in the BaseChat class.

## Type of change

- [ ] Internal refactoring
- [X] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
